### PR TITLE
Annotation support for different ASM formats

### DIFF
--- a/annotate
+++ b/annotate
@@ -1,4 +1,9 @@
+# Make sure that there is an ASM_FORMAT no matter
+# how we were called.
+if [ "${ASM_FORMAT}" == "" ]; then
+	ASM_FORMAT="att"
+fi
 while read line ;
 do echo "----------- $line" >> bench.perf
-perf annotate --stdio $line >> bench.perf ;
+perf annotate -M${ASM_FORMAT} --stdio $line >> bench.perf ;
 done <bench.func


### PR DESCRIPTION
Add support for different ASM formats in the annotated disassembly! In re: https://github.com/FredTingaud/quick-bench-front-end/issues/23

This will be part of a fleet of patches across each of the repositories for adding this support!

Bonus: Add support for `--notest` when building images. This feature helps users who do not have the time/prereqs for successfully executing tests.