### PR TITLE
Add gcc 11.3 released on April 21, 2022

### DIFF
--- a/containers.json
+++ b/containers.json
@@ -87,6 +87,10 @@
   "clang-3.8": {
     "docker": "clang38-dockerfile"
   },
+  "gcc-11.3": {
+    "docker": "gcc-dockerfile",
+    "GCC_VERSION": "11.3.0"
+  },
   "gcc-11.2": {
     "docker": "gcc-dockerfile",
     "GCC_VERSION": "11.2.0"


### PR DESCRIPTION
See FredTingaud/quick-bench-front-end#64 for the patch in the front-end.

I was able to successfully construct the corresponding Docker image with your script: `python build-container.py gcc-11.3`
I let you build it again on your side and push it to your Docker Hub account @FredTingaud 
Thanks again for this utility!